### PR TITLE
Convert EDM data types into CLR types for query executors

### DIFF
--- a/Source/DynamicODataToSQL/FilterClauseBuilder.cs
+++ b/Source/DynamicODataToSQL/FilterClauseBuilder.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 
+using Microsoft.OData.Edm;
 using Microsoft.OData.UriParser;
 
 using SqlKata;
@@ -200,10 +201,10 @@ public class FilterClauseBuilder(Query query, bool tryToParseDates, ColumnNameRe
                 query = query.WhereDatePart(leftNode.Name, columnName, operand, rightValue);
                 break;
             case "DATE":
-                query = query.WhereDate(columnName, operand, rightValue is DateTime date ? date.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture.DateTimeFormat) : rightValue);
+                query = query.WhereDate(columnName, operand, rightValue);
                 break;
             case "TIME":
-                query = query.WhereTime(columnName, operand, rightValue is DateTime time ? time.ToString("HH:mm", CultureInfo.InvariantCulture.DateTimeFormat) : rightValue);
+                query = query.WhereTime(columnName, operand, rightValue);
                 break;
             case "TOUPPER":
             case "TOLOWER":
@@ -296,8 +297,20 @@ public class FilterClauseBuilder(Query query, bool tryToParseDates, ColumnNameRe
 
                 return trimedValue;
             }
-
-            return value;
+            else if (value is Date date)
+            {
+                DateTime converted = date;
+                return converted;
+            }
+            else if (value is TimeOfDay timeOfDay)
+            {
+                TimeSpan converted = timeOfDay;
+                return converted;
+            }
+            else
+            {
+                return value;
+            }
         }
         else if (node.Kind == QueryNodeKind.CollectionConstant)
         {

--- a/Tests/DynamicODataToSQL.Test/ODataToSqlConverterTests.cs
+++ b/Tests/DynamicODataToSQL.Test/ODataToSqlConverterTests.cs
@@ -255,7 +255,7 @@ public class ODataToSqlConverterTests(ITestOutputHelper output)
                 {"filter","date(OrderDate) gt 2001-01-17" }
             };
             var expectedSQL = @"SELECT * FROM [Orders] WHERE CAST([Orders].[OrderDate] as DATE) > @p0";
-            var expectedSQLParams = new Dictionary<string, object> { { "@p0", new Microsoft.OData.Edm.Date(2001, 1, 17) } };
+            var expectedSQLParams = new Dictionary<string, object> { { "@p0", new DateTime(2001, 1, 17) } };
             yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams, false, expectedSQL, expectedSQLParams };
         }
 
@@ -269,7 +269,7 @@ public class ODataToSqlConverterTests(ITestOutputHelper output)
                 {"filter","time(OrderDate) gt 16:30" }
             };
             var expectedSQL = @"SELECT * FROM [Orders] WHERE CAST([Orders].[OrderDate] as TIME) > @p0";
-            var expectedSQLParams = new Dictionary<string, object> { { "@p0", new Microsoft.OData.Edm.TimeOfDay(16, 30, 0, 0) } };
+            var expectedSQLParams = new Dictionary<string, object> { { "@p0", new TimeSpan(0, 16, 30, 0, 0) } };
             yield return new object[] { testName, tableName, tryToParseDates, odataQueryParams, false, expectedSQL, expectedSQLParams };
         }
         // Test 14


### PR DESCRIPTION
SQL query runners (eg, dapper) don't know how to handle the EDM types. When converting constants into a filter term, we need to handle converting the EDM type into a native CLR type.